### PR TITLE
Remove static linking for compatibility with modern Linux systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,8 @@ elseif (WIN32)
 		winmm
 		)
 else()
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -static")
-	set(CMAKE_CPP_FLAGS "${CMAKE_C_FLAGS} -Wall -static")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+	set(CMAKE_CPP_FLAGS "${CMAKE_C_FLAGS} -Wall")
 	target_link_libraries(rogue-clone
 		ncurses
 		tinfo


### PR DESCRIPTION
This PR removes the hardcoded `-static` linker flag from the Linux build path in `CMakeLists.txt`.

On modern Linux distributions — particularly Arch Linux with glibc 2.41 and GCC 15.1.1 — static linking is no longer supported by default. Most `.a` libraries (like `libc.a`, `libncurses.a`, etc.) are not shipped or are deprecated, and forcing static linking results in failed builds or linker errors.

By removing `-static`, this change allows the project to:
- Build successfully using shared libraries
- Improve compatibility across modern distros (Arch, Fedora, Ubuntu)
- Avoid unnecessary dependencies on unavailable static archives

Tested on:
- Arch Linux (glibc 2.41, GCC 15.1.1, CMake 4.0.3)

Let me know if you'd prefer this behind a toggle (`FORCE_STATIC` option), but this PR takes the simplest and most robust path for now.